### PR TITLE
fix: Update setup_minion.sh to work with ubuntu22

### DIFF
--- a/setup_minion.sh
+++ b/setup_minion.sh
@@ -46,6 +46,7 @@ UBUNTU_VERSION_CODENAME=$(lsb_release -c | cut -f2)
 
 # Determine the Salt version we wish to install
 declare -A SALT_VERSION_MAP
+SALT_VERSION_MAP["22.04"]="3005"
 SALT_VERSION_MAP["20.04"]="3002"
 SALT_VERSION_MAP["18.04"]="3002"
 SALT_VERSION_MAP["16.04"]="3002"
@@ -67,10 +68,15 @@ fi
 banner "Installing salt-minion"
 
 # Add repository gpg public key
-wget -O - https://repo.saltstack.com/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
+if [[ $SALT_VERSION -eq "3005" ]]; then
+    curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}/salt-archive-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION} jammy main" | sudo tee /etc/apt/sources.list.d/salt.list
+else
+    wget -O - https://repo.saltstack.com/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
 
-# Add repository to apt sources
-echo "deb http://repo.saltstack.com/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION} ${UBUNTU_VERSION_CODENAME} main" > /etc/apt/sources.list.d/saltstack.list
+    # Add repository to apt sources
+    echo "deb http://repo.saltstack.com/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION} ${UBUNTU_VERSION_CODENAME} main" > /etc/apt/sources.list.d/saltstack.list
+fi
 
 # Update apt cache
 sudo apt-get update

--- a/setup_minion.sh
+++ b/setup_minion.sh
@@ -69,8 +69,8 @@ banner "Installing salt-minion"
 
 # Add repository gpg public key
 if [[ $SALT_VERSION -eq "3005" ]]; then
-    curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}/salt-archive-keyring.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION} jammy main" | sudo tee /etc/apt/sources.list.d/salt.list
+    curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/minor${SALT_VERSION}.3/salt-archive-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}.3 jammy main" | sudo tee /etc/apt/sources.list.d/salt.list
 else
     wget -O - https://repo.saltstack.com/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
 

--- a/setup_minion.sh
+++ b/setup_minion.sh
@@ -70,7 +70,7 @@ banner "Installing salt-minion"
 # Add repository gpg public key
 if [[ $SALT_VERSION -eq "3005" ]]; then
     curl -fsSL -o /etc/apt/keyrings/salt-archive-keyring.gpg https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/minor${SALT_VERSION}.3/salt-archive-keyring.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}.3 jammy main" | sudo tee /etc/apt/sources.list.d/salt.list
+    echo "deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/salt/py3/ubuntu/${UBUNTU_VERSION}/amd64/minor/${SALT_VERSION}.3 jammy main" | sudo tee /etc/apt/sources.list.d/salt.list
 else
     wget -O - https://repo.saltstack.com/py3/ubuntu/${UBUNTU_VERSION}/amd64/${SALT_VERSION}/SALTSTACK-GPG-KEY.pub | sudo apt-key add -
 


### PR DESCRIPTION
When using on minion based on Ubuntu 22.04, the script crashes.
This modified script has been tested in magenta-grønlands servers for a while, and works as intended