### PR TITLE
fix: [#71071] upgrade salt-version

### DIFF
--- a/setup_minion.sh
+++ b/setup_minion.sh
@@ -60,7 +60,7 @@ curl -fsSL https://github.com/saltstack/salt-install-guide/releases/latest/downl
 
 # Pin salt
 echo 'Package: salt-*
-Pin: version 3006.14
+Pin: version 3006.26
 Pin-Priority: 1001' | sudo tee /etc/apt/preferences.d/salt-pin-1001
 
 # Update apt cache


### PR DESCRIPTION
Upgrade salt-version in minion bootstrapping script